### PR TITLE
Allow to specifiy a gene prefix from the command line for gene names

### DIFF
--- a/src/assembler.cc
+++ b/src/assembler.cc
@@ -145,7 +145,7 @@ int assembler::assemble(const splice_graph &gr0, const hyper_set &hs0)
 	vector<transcript> gv;
 	for(int k = 0; k < sg.subs.size(); k++)
 	{
-		string gid = "gene." + tostring(index) + "." + tostring(k);
+		string gid = gene_prefix + tostring(index) + "." + tostring(k);
 		if(fixed_gene_name != "" && gid != fixed_gene_name) continue;
 
 		if(verbose >= 2 && (k == 0 || fixed_gene_name != "")) sg.print();

--- a/src/config.cc
+++ b/src/config.cc
@@ -65,6 +65,7 @@ int simulation_max_edge_weight = 0;
 
 // input and output
 string algo = "scallop";
+string gene_prefix = "gene.";
 string input_file;
 string ref_file;
 string ref_file1;
@@ -340,6 +341,13 @@ int parse_arguments(int argc, const char ** argv)
 		else if(string(argv[i]) == "--batch_bundle_size")
 		{
 			batch_bundle_size = atoi(argv[i + 1]);
+			i++;
+		}
+		else if(string(argv[i]) == "--gene-prefix")
+		{
+			string new_prefix = argv[i + 1];
+			if(!new_prefix.empty()) gene_prefix = std::move(new_prefix);
+			if(gene_prefix.back() != '.') gene_prefix += '.';
 			i++;
 		}
 	}

--- a/src/config.h
+++ b/src/config.h
@@ -88,6 +88,7 @@ extern int simulation_max_edge_weight;
 
 // input and output
 extern string algo;
+extern string gene_prefix;
 extern string input_file;
 extern string ref_file;
 extern string ref_file1;


### PR DESCRIPTION
* add option --gene-prefix

* use this prefix (with a '.' added if needed) as the prefix for gene
  names instead of 'gene.'